### PR TITLE
Mp2

### DIFF
--- a/input.mesp
+++ b/input.mesp
@@ -7,10 +7,20 @@ geom = """
     O
     H 1 1
     H 1 1 2 104.5
+    symmetry c1
 """
 
 bas = "sto-3g"
 
+psi4.set_options({
+    'basis':bas,
+    'mp2_type':'conv',
+    'freeze_core':'false',
+    'e_convergence':1e-12,
+    'd_convergence':1e-12})
+
 mol = mesp.Molecule('H2O',geom,bas)
 
-mesp.scf.do_scf(mol)
+mesp.do_scf(mol)
+
+mesp.mp2.do_mp2(mol)

--- a/mesp/__init__.py
+++ b/mesp/__init__.py
@@ -4,6 +4,8 @@ Primary init
 
 from . import molecule
 from . import scf
+from . import mp2
 
 from .molecule import Molecule
 from .scf import do_scf
+from .mp2 import do_mp2

--- a/mesp/molecule.py
+++ b/mesp/molecule.py
@@ -15,13 +15,15 @@ class Molecule:
         # Leave some space to store other things
         self.C  = None  # MO coefficient matrix
         self.D  = None  # Density
-        self.g  = None  # bleh
+        self.g  = None  # Might not need to save this
         self.Hc = None  # Core Hamiltonian
         self.H  = None  # Hamiltonian
         self.J  = None  # Coulomb
         self.K  = None  # Exchange
+        self.eps = False # SCF orbital energies
 
         # Progress
         self.scf_computed = False
+        self.mp2_computed = False
         self.E_SCF = False
-        self.eps = False # Orbital energies from SCF
+        self.E_MP2 = False

--- a/mesp/mp2.py
+++ b/mesp/mp2.py
@@ -1,5 +1,6 @@
 import numpy as np
 import psi4
+import mesp
 
 def do_mp2(mol):
     '''
@@ -9,8 +10,32 @@ def do_mp2(mol):
     ----------
     mol: MESP Molecule class
     '''
-    
-    mints = psi4.core.MintsHelper(mol.p4wfn.basisset()) # build a mints helper
-    eri = np.asarray(mints.ao_eri()) # grab the 2-electron integrals in ao basis
 
-    MO = np.einsum('ip,jq,kr,ls->pqrs',mol.C,mol.C,eri,mol.C,mol.C) # transform to MO basis
+    ### SETUP ###
+    if not mol.scf_computed:
+        mesp.do_scf(mol)
+    
+    # Make a Mints helper and grab AO integrals from psi4
+    # Then transform them to MO basis
+    mints = psi4.core.MintsHelper(mol.p4wfn.basisset()) 
+    eri = np.asarray(mints.ao_eri()) 
+#    MO = np.einsum('ip,jq,ijkl,kr,ls->pqrs',mol.C,mol.C,eri,mol.C,mol.C)
+
+    ndocc = int(mol.nel / 2.) # number of doubly occ orbitals
+    Co = mol.C[:,:ndocc]
+    Cv = mol.C[:,ndocc:]
+    MO = np.einsum('ip,jq,ijkl,kr,ls->pqrs',Co,Cv,eri,Co,Cv)
+
+    o = mol.eps[:ndocc] # first ndocc orbital energies
+    v = mol.eps[ndocc:] # virtual orbital energies
+
+    D_ijab = 1 / (o.reshape(-1,1,1,1) + o.reshape(-1,1,1) - v.reshape(-1,1) - v) # similar to CCSD denominator
+
+    E_1 = np.einsum('iajb,iajb,ijab->',MO,MO,D_ijab)
+    E_2 = np.einsum('iajb,ibja,ijab->',MO,MO,D_ijab)
+
+    E_MP2 = 2*E_1 - E_2 + mol.E_SCF
+    mol.mp2_computed = True
+    mol.E_MP2 = E_MP2
+    print("MP2 energy computed!")
+    print("MP2 energy = {}".format(E_MP2))

--- a/mesp/mp2.py
+++ b/mesp/mp2.py
@@ -1,0 +1,16 @@
+import numpy as np
+import psi4
+
+def do_mp2(mol):
+    '''
+    MP2 function
+    
+    Parameters
+    ----------
+    mol: MESP Molecule class
+    '''
+    
+    mints = psi4.core.MintsHelper(mol.p4wfn.basisset()) # build a mints helper
+    eri = np.asarray(mints.ao_eri()) # grab the 2-electron integrals in ao basis
+
+    MO = np.einsum('ip,jq,kr,ls->pqrs',mol.C,mol.C,eri,mol.C,mol.C) # transform to MO basis

--- a/tests/test_mp2.py
+++ b/tests/test_mp2.py
@@ -1,0 +1,37 @@
+import numpy as np
+import psi4
+psi4.core.be_quiet()
+import mesp
+
+geom = """
+    O
+    H 1 1
+    H 1 1 2 104.5
+    symmetry c1
+"""
+bas = "sto-3g"
+mol = mesp.Molecule('H2O',geom,bas)
+
+def test_mp2():
+    mesp.mp2.do_mp2(mol)
+    E_mesp = mol.E_MP2    
+
+    psi4.set_options({
+        'basis':bas,
+        'mp2_type':'conv',
+        'freeze_core':'false',
+        'e_convergence':1e-12,
+        'd_convergence':1e-12})
+    psi4.set_module_options(
+        'SCF', {
+            'e_convergence': 1e-12, 
+            'd_convergence': 1e-12,
+            'DIIS': False,
+            'scf_type':'pk'})
+    E_psi4 = psi4.energy('MP2')
+    
+    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
+    assert np.allclose(E_psi4,E_mesp)
+
+if __name__=="__main__":
+    test_mp2()


### PR DESCRIPTION
Adds MP2 to list of computable energies. Includes test case, and more robust `psi4.set_options` call in sample input to help facilitate benchmarking (generally to 12 decimal places). 