### PR TITLE
UGACC: CCSD and CC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ py.test
 ### Implemented methods:
 * SCF
 * MP2
-* CCSD (spin orbital)
-* CC2  (cut-down SO CCSD)
+* CCSD (spin-adapted and spin-orbital)
+* CC2  (spin-adapted and spin-orbital)

--- a/input.mesp
+++ b/input.mesp
@@ -24,7 +24,7 @@ mol = mesp.Molecule('H2O',geom,bas)
 
 mesp.do_scf(mol)
 
-mesp.do_mp2(mol)
+#mesp.do_mp2(mol)
 
-#mesp.do_ccsd(mol)
-mesp.do_cc2(mol)
+mesp.do_ccsd(mol)
+#mesp.do_cc2(mol)

--- a/mesp/__init__.py
+++ b/mesp/__init__.py
@@ -8,6 +8,7 @@ from . import mp2
 from . import ccsd
 from . import so_ccsd
 from . import cc2
+from . import so_cc2
 
 from .molecule import Molecule
 from .scf import do_scf
@@ -15,3 +16,4 @@ from .mp2 import do_mp2
 from .ccsd import do_ccsd
 from .so_ccsd import do_so_ccsd
 from .cc2 import do_cc2
+from .so_cc2 import do_so_cc2

--- a/mesp/__init__.py
+++ b/mesp/__init__.py
@@ -6,9 +6,12 @@ from . import molecule
 from . import scf
 from . import mp2
 from . import ccsd
+from . import so_ccsd
+from . import cc2
 
 from .molecule import Molecule
 from .scf import do_scf
 from .mp2 import do_mp2
 from .ccsd import do_ccsd
+from .so_ccsd import do_so_ccsd
 from .cc2 import do_cc2

--- a/mesp/cc2.py
+++ b/mesp/cc2.py
@@ -79,16 +79,13 @@ def do_cc2(mol,
 #        print("Iteration {} . . .".format(cc2_iter))
 
         # Build tau intermediates
-        tau = build_tau(t1,t2)
-        aprx_tau = build_tau(t1,t2,aprx=True)
-        tildetau = build_tildetau(t1,t2)
+        tau = build_tau(t1,t2,aprx=True) # aprx tau, don't need full
+        tildetau = build_tildetau(t1,t2) # full ttau, don't need aprx
 
         # Build 2- and 4-index intermediates
         Fvv, Foo, Fov = build_F(F,L,ov,t1,t2,tildetau)
-        aprx_Fvv, aprx_Foo = build_F(F,L,ov,t1,t2,tildetau,aprx=True)
-#        Woooo, Wovov, Wovvo = build_W(MO,L,ov,t1,t2,tau)
-        Woooo, Wovov = build_W(MO,L,ov,t1,t2,aprx_tau,aprx=True)
-        Z = build_Z(MO,ov,aprx_tau) 
+        Woooo, Wovov = build_W(MO,L,ov,t1,t2,tau,aprx=True) # aprx W's (from tau)
+        Z = build_Z(MO,ov,tau) # aprx Z (from tau)
 
         # Build T1
         T1 = F[ov[0],ov[1]].copy()
@@ -113,8 +110,8 @@ def do_cc2(mol,
 #        T2 -= 0.5*np.einsum('imab,je,me->ijab',t2,t1,Fov)
 #        T2 -= 0.5*np.einsum('mjab,ie,me->ijab',t2,t1,Fov)
 
-        T2 += np.einsum('mnab,mnij->ijab',aprx_tau,Woooo) # should I wrap in the t2*MO component?
-        T2 += np.einsum('ijef,abef->ijab',aprx_tau,MO[ov[1],ov[1],ov[1],ov[1]])
+        T2 += np.einsum('mnab,mnij->ijab',tau,Woooo) 
+        T2 += np.einsum('ijef,abef->ijab',tau,MO[ov[1],ov[1],ov[1],ov[1]])
         T2 += np.einsum('ie,abej->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
         T2 += np.einsum('je,baei->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
 
@@ -220,6 +217,7 @@ def build_F(F,L,ov,t1,t2,tildetau,aprx=False):
         return fvv, foo
 
 # 4-INDEX INTERMEDIATES
+## here aprx will keep only pure MO terms
 def build_Woooo(MO,ov,t1,t2,tau):
     '''EQ 6'''
     woooo = MO[ov[0],ov[0],ov[0],ov[0]].copy()

--- a/mesp/ccsd.py
+++ b/mesp/ccsd.py
@@ -11,7 +11,15 @@ def do_ccsd(mol,
     Parameters
     ----------
     mol: MESP Molecule class
-    max_iter: int, maximum iterations for CCSD
+    e_conv: optional float (default = 1e-12), convergence criteria for energy
+    max_iter: optional int (default = 50), maximum iterations for CCSD
+
+    Notes
+    ----------
+    This is a spatial-orbital code derived using the Unitary Group Generator Approach.
+    Equations were matched with Prof. Crawford's UGACC, factorized roughly according
+    to the Stanton1991 CCSD intermediates.
+    https://github.com/lothian/ugacc/blob/master/ccwfn.cc
     '''
     
     ### SETUP ###
@@ -21,25 +29,24 @@ def do_ccsd(mol,
     # Make a Mints helper and grab integrals from psi4
     mints = psi4.core.MintsHelper(mol.p4wfn.basisset())
     C_p4 = psi4.core.Matrix.from_array(mol.C) # need p4 Matrix
-    MO = np.asarray(mints.mo_spin_eri(C_p4,C_p4)) # antisymmetrized SO MO ERI
+    MO = np.asarray(mints.mo_eri(C_p4,C_p4,C_p4,C_p4)) # MO ERI
+    MO = MO.swapaxes(1,2) # Physicist notation
 
-    nso = MO.shape[0] # convenient number of spin orbitals
-    nocc = int(mol.nel) # number of occ orbitals
-    nvir = nso - nocc # number of vir orbitals
-    so_eps = np.repeat(mol.eps, 2) # spin-orbital sfc orbital energies
+    no = MO.shape[0] # convenient number of orbitals
+    nocc = int(mol.nel / 2) # number of doubly occ orbitals
+    nvir = no - nocc # number of vir orbitals
 
     F = mol.Hc + 2*mol.J - mol.K # AO-basis Fock
     F = np.einsum('uj,vi,uv', mol.C, mol.C, F) # MO-basis Fock
-    I = np.array([[1,0],
-                  [0,1]])
-    F = np.kron(F,I) # Expand and spin-tegrate, thanks Vibin!
 
     # use slices to cut out occ and vir blocks
     o = slice(0,nocc) 
-    v = slice(nocc,nso)
+    v = slice(nocc,no)
     ov = (o,v) # tuple for passing into functions
 
-    MO_ijab = MO[o,o,v,v] # <ij||ab>
+    MO_ijab = MO[o,o,v,v] # <ij|ab>
+    L = 2*MO - MO.swapaxes(2,3) # L_{ijab} = 2*<ij|ab> - <ij|ba>
+                                # Also called gbar in Prof. Valeev's notation
 
     # Grab orbital energies. I know I could just tile mol.eps,
     # but this is a good check if my Fock is correct
@@ -56,7 +63,9 @@ def do_ccsd(mol,
     t2 = MO_ijab / D_ijab
 
     if not mol.mp2_computed:
-        E_MP2_CORR = 0.25 * np.einsum('ijab,ijab->',MO_ijab,t2)
+        tau = build_tau(t1,t2)
+        E_MP2_CORR = 2*np.einsum('ia,ia->',F[ov[0],ov[1]],t1)
+        E_MP2_CORR += np.einsum('ijab,ijab->',tau,L[ov[0],ov[0],ov[1],ov[1]])
         E_MP2 = E_MP2_CORR + mol.E_SCF
         mol.E_MP2 = E_MP2
         print('MP2 energy (from CCSD) = {}'.format(E_MP2))
@@ -64,71 +73,89 @@ def do_ccsd(mol,
     # Start CCSD iterations
     E_old = 0.0
     for ccsd_iter in range(1,max_iter):
+#        print("Iteration {} . . .".format(ccsd_iter))
+
+        # Build tau intermediates
+        tau = build_tau(t1,t2)
+        tildetau = build_tildetau(t1,t2)
+
         # Build 2- and 4-index intermediates
-        Fae = build_Fae(F,MO,ov,t1,t2)
-        Fmi = build_Fmi(F,MO,ov,t1,t2)
-        Fme = build_Fme(F,MO,ov,t1)
-        Wmnij = build_Wmnij(MO,ov,t1,t2)
-        Wabef = build_Wabef(MO,ov,t1,t2)
-        Wmbej = build_Wmbej(MO,ov,t1,t2)
+        Fvv, Foo, Fov = build_F(F,L,ov,t1,t2,tildetau)
+        Woooo, Wovov, Wovvo = build_W(MO,L,ov,t1,t2,tau)
+        Z = build_Z(MO,ov,tau)
 
         # Build T1
         T1 = F[ov[0],ov[1]].copy()
-        T1 += np.einsum('ie,ae->ia',t1,Fae)
-        T1 -= np.einsum('ma,mi->ia',t1,Fmi)
-        T1 += np.einsum('imae,me->ia',t2,Fme)
-        T1 -= np.einsum('nf,naif->ia',t1,MO[ov[0],ov[1],ov[0],ov[1]])
-        T1 -= 0.5 * np.einsum('imef,maef->ia',t2,MO[ov[0],ov[1],ov[1],ov[1]])
-        T1 -= 0.5 * np.einsum('mnae,nmei->ia',t2,MO[ov[0],ov[0],ov[1],ov[0]])
+        T1 += np.einsum('ie,ae->ia',t1,Fvv)
+        T1 -= np.einsum('ma,mi->ia',t1,Foo)
+        T1 += 2*np.einsum('miea,me->ia',t2,Fov)
+        T1 -= np.einsum('miae,me->ia',t2,Fov)
+        T1 += np.einsum('nf,nafi->ia',t1,L[ov[0],ov[1],ov[1],ov[0]])
+        T1 += 2*np.einsum('inef,anef->ia',t2,MO[ov[1],ov[0],ov[1],ov[1]])
+        T1 -= np.einsum('infe,anef->ia',t2,MO[ov[1],ov[0],ov[1],ov[1]])
+        T1 -= np.einsum('mnea,mnei->ia',t2,L[ov[0],ov[0],ov[1],ov[0]])
 
         # Build T2
         T2 = MO[ov[0],ov[0],ov[1],ov[1]].copy()
-        tmp = 0.5 * np.einsum('mb,me->be',t1,Fme)
-        tmp = Fae - tmp
-        T2 += np.einsum('ijae,be->ijab',t2,tmp)
-        T2 -= np.einsum('ijbe,ae->ijab',t2,tmp) # Questionable- rebuild tmp with P(ab)?
+        T2 += np.einsum('ijae,be->ijab',t2,Fvv)
+        T2 += np.einsum('jibe,ae->ijab',t2,Fvv)
+        T2 -= 0.5*np.einsum('ijae,mb,me->ijab',t2,t1,Fov)
+        T2 -= 0.5*np.einsum('ijeb,ma,me->ijab',t2,t1,Fov)
 
-        tmp = 0.5 * np.einsum('je,me->mj',t1,Fme)
-        tmp = Fmi + tmp
-        T2 -= np.einsum('imab,mj->ijab',t2,tmp)
-        T2 += np.einsum('jmab,mi->ijab',t2,tmp) # Also questionable
+        T2 -= np.einsum('imab,mj->ijab',t2,Foo)
+        T2 -= np.einsum('mjab,mi->ijab',t2,Foo)
+        T2 -= 0.5*np.einsum('imab,je,me->ijab',t2,t1,Fov)
+        T2 -= 0.5*np.einsum('mjab,ie,me->ijab',t2,t1,Fov)
 
-        tau = build_tau(t1,t2)
-        T2 += 0.5 * np.einsum('mnab,mnij->ijab',tau,Wmnij)
-        T2 += 0.5 * np.einsum('ijef,abef->ijab',tau,Wabef)
-
-        T2 -= np.einsum('ie,ma,mbej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
-        T2 += np.einsum('imae,mbej->ijab',t2,Wmbej)
-        T2 += np.einsum('ie,mb,maej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
-        T2 -= np.einsum('imbe,maej->ijab',t2,Wmbej)
-        T2 += np.einsum('je,ma,mbei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
-        T2 -= np.einsum('jmae,mbei->ijab',t2,Wmbej)
-        T2 -= np.einsum('je,mb,maei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
-        T2 += np.einsum('jmbe,maei->ijab',t2,Wmbej)
-
+        T2 += np.einsum('mnab,mnij->ijab',tau,Woooo)
+        T2 += np.einsum('ijef,abef->ijab',tau,MO[ov[1],ov[1],ov[1],ov[1]])
         T2 += np.einsum('ie,abej->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
-        T2 -= np.einsum('je,abei->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
+        T2 += np.einsum('je,baei->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
 
         T2 -= np.einsum('ma,mbij->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
-        T2 += np.einsum('mb,maij->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
+        T2 -= np.einsum('mb,maji->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
+        T2 += np.einsum('imae,mbej->ijab',t2,Wovvo)
+        T2 -= np.einsum('imea,mbej->ijab',t2,Wovvo)
+
+        T2 += np.einsum('imae,mbej->ijab',t2,Wovvo)
+        T2 += np.einsum('imae,mbje->ijab',t2,Wovov)
+        T2 += np.einsum('mjae,mbie->ijab',t2,Wovov)
+        T2 += np.einsum('imeb,maje->ijab',t2,Wovov)
+
+        T2 += np.einsum('jmbe,maei->ijab',t2,Wovvo)
+        T2 += np.einsum('jmbe,maie->ijab',t2,Wovov)
+        T2 += np.einsum('jmbe,maei->ijab',t2,Wovvo)
+        T2 -= np.einsum('jmeb,maei->ijab',t2,Wovvo)
+
+        T2 -= np.einsum('ie,ma,mbej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+        T2 -= np.einsum('ie,mb,maje->ijab',t1,t1,MO[ov[0],ov[1],ov[0],ov[1]])
+        T2 -= np.einsum('je,ma,mbie->ijab',t1,t1,MO[ov[0],ov[1],ov[0],ov[1]])
+        T2 -= np.einsum('je,mb,maei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+
+        tmp = np.einsum('ma,mbij->ijab',t1,Z)
+        T2 -= tmp
+        T2 -= tmp.swapaxes(0,1).swapaxes(2,3)
 
         # Update t1 and t2 amplitudes
+#        t1 += (T1 / D_ia)
+#        t2 += (T2 / D_ijab)
         t1 = T1 / D_ia
         t2 = T2 / D_ijab
 
         # Calculate the current CCSD correlation energy
-        E_CCSD_CORR = np.einsum('ia,ia->',F[ov[0],ov[1]],t1)
-        E_CCSD_CORR += 0.25 * np.einsum('ijab,ijab->',MO_ijab,t2)
-        E_CCSD_CORR += 0.5 * np.einsum('ijab,ia,jb->',MO_ijab,t1,t1)
-#        print("Iteration {} . . .".format(ccsd_iter))
-#        print("CCSD Correlation Energy = {}".format(E_CCSD_CORR))
+        tau = build_tau(t1,t2)
+        one_E = 2*np.einsum('ia,ia->',F[ov[0],ov[1]],t1)
+        two_E = np.einsum('ijab,ijab->',tau,L[ov[0],ov[0],ov[1],ov[1]])
+        E_CCSD_CORR = one_E + two_E
+#        print("one_E = {}\ntwo_E = {}".format(one_E,two_E))
+#        print("CCSD Correlation Energy = {}\n\n".format(E_CCSD_CORR))
 
         # Check convergence
         if (abs(E_CCSD_CORR - E_old) < e_conv):
             E_CCSD = E_CCSD_CORR + mol.E_SCF
             mol.E_CCSD = E_CCSD
             mol.ccsd_computed = True
-            print("CCSD converged in {} steps!\nCCSD Energy = {}".format(ccsd_iter,E_CCSD))
+            print('CCSD converged in {} steps!\nCCSD Energy = {}'.format(ccsd_iter,E_CCSD))
             break
         else:
             E_old = E_CCSD_CORR
@@ -140,65 +167,78 @@ def do_ccsd(mol,
 def build_tau(t1,t2):
     '''EQ 9'''
     tau = t2 + np.einsum('ia,jb->ijab',t1,t1)
-    tau -= np.einsum('ib,ja->ijab',t1,t1)
     return tau
 
 def build_tildetau(t1,t2):
     '''EQ 10'''
     tildetau = t2 + 0.5 * np.einsum('ia,jb->ijab',t1,t1)
-    tildetau -= 0.5 * np.einsum('ib,ja->ijab',t1,t1)
     return tildetau
 
 # 2-INDEX INTERMEDIATES
-def build_Fae(F,MO,ov,t1,t2):
+def build_Fvv(F,L,ov,t1,t2,tildetau):
     '''EQ 3'''
-    fae = F[ov[1],ov[1]].copy() # only need vir-vir block 
-    fae[np.diag_indices_from(fae)] = 0 # only need off-diag elements
-    fae -= 0.5 * np.einsum('me,ma->ae',F[ov[0],ov[1]],t1)
-    fae += np.einsum('mf,mafe->ae',t1,MO[ov[0],ov[1],ov[1],ov[1]])
-    tildetau = build_tildetau(t1,t2)
-    fae -= 0.5 * np.einsum('mnaf,mnef->ae',tildetau,MO[ov[0],ov[0],ov[1],ov[1]])
-    return fae
+    fvv = F[ov[1],ov[1]].copy() # only need vir-vir block 
+    fvv[np.diag_indices_from(fvv)] = 0 # only need off-diag elements
+    fvv -= 0.5 * np.einsum('me,ma->ae',F[ov[0],ov[1]],t1)
+    fvv += np.einsum('mf,mafe->ae',t1,L[ov[0],ov[1],ov[1],ov[1]])
+    fvv -=  np.einsum('mnfa,mnfe->ae',tildetau,L[ov[0],ov[0],ov[1],ov[1]])
+    return fvv
 
-def build_Fmi(F,MO,ov,t1,t2):
+def build_Foo(F,L,ov,t1,t2,tildetau):
     '''EQ 4'''
-    fmi = F[ov[0],ov[0]].copy() # occ-occ block
-    fmi[np.diag_indices_from(fmi)] = 0 # only need off-diag elements
-    fmi += 0.5 * np.einsum('ie,me->mi',t1,F[ov[0],ov[1]])
-    fmi += np.einsum('ne,mnie->mi',t1,MO[ov[0],ov[0],ov[0],ov[1]])
-    tildetau = build_tildetau(t1,t2)
-    fmi += 0.5 * np.einsum('inef,mnef->mi',tildetau,MO[ov[0],ov[0],ov[1],ov[1]])
-    return fmi
+    foo = F[ov[0],ov[0]].copy() # occ-occ block
+    foo[np.diag_indices_from(foo)] = 0 # only need off-diag elements
+    foo += 0.5 * np.einsum('me,ie->mi',F[ov[0],ov[1]],t1)
+    foo += np.einsum('ne,mnie->mi',t1,L[ov[0],ov[0],ov[0],ov[1]])
+    foo += np.einsum('infe,mnfe->mi',tildetau,L[ov[0],ov[0],ov[1],ov[1]])
+    return foo
 
-def build_Fme(F,MO,ov,t1):
+def build_Fov(F,L,ov,t1):
     '''EQ 5'''
-    fme = F[ov[0],ov[1]].copy() + np.einsum('nf,mnef->me',t1,MO[ov[0],ov[0],ov[1],ov[1]])
-    return fme
+    fov = F[ov[0],ov[1]].copy() + np.einsum('nf,mnef->me',t1,L[ov[0],ov[0],ov[1],ov[1]])
+    return fov
+
+def build_F(F,L,ov,t1,t2,tildetau):
+    fvv = build_Fvv(F,L,ov,t1,t2,tildetau)
+    foo = build_Foo(F,L,ov,t1,t2,tildetau)
+    fov = build_Fov(F,L,ov,t1)
+    return fvv, foo, fov
 
 # 4-INDEX INTERMEDIATES
-def build_Wmnij(MO,ov,t1,t2):
+def build_Woooo(MO,ov,t1,t2,tau):
     '''EQ 6'''
-    wmnij = MO[ov[0],ov[0],ov[0],ov[0]].copy()
-    wmnij += np.einsum('je,mnie->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
-    wmnij -= np.einsum('ie,mnje->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
-    tau = build_tau(t1,t2)
-    wmnij += 0.25 * np.einsum('ijef,mnef->mnij',tau,MO[ov[0],ov[0],ov[1],ov[1]])
-    return wmnij
+    woooo = MO[ov[0],ov[0],ov[0],ov[0]].copy()
+    woooo += np.einsum('je,mnie->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+    woooo += np.einsum('ie,mnej->mnij',t1,MO[ov[0],ov[0],ov[1],ov[0]])
+    woooo += np.einsum('ijef,mnef->mnij',tau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return woooo
 
-def build_Wabef(MO,ov,t1,t2):
-    '''EQ 7'''
-    wabef = MO[ov[1],ov[1],ov[1],ov[1]].copy()
-    wabef -= np.einsum('mb,amef->abef',t1,MO[ov[1],ov[0],ov[1],ov[1]])
-    wabef += np.einsum('ma,bmef->abef',t1,MO[ov[1],ov[0],ov[1],ov[1]])
-    tau = build_tau(t1,t2)
-    wabef += 0.25 * np.einsum('mnab,mnef->abef',tau,MO[ov[0],ov[0],ov[1],ov[1]])
-    return wabef
-
-def build_Wmbej(MO,ov,t1,t2):
-    '''EQ 8'''
-    wmbej = MO[ov[0],ov[1],ov[1],ov[0]].copy()
-    wmbej += np.einsum('jf,mbef->mbej',t1,MO[ov[0],ov[1],ov[1],ov[1]])
-    wmbej -= np.einsum('nb,mnej->mbej',t1,MO[ov[0],ov[0],ov[1],ov[0]])
+def build_Wovov(MO,ov,t1,t2,tau):
+    '''EQ 7- now Wovov and Z'''
+    wovov = -1*MO[ov[0],ov[1],ov[0],ov[1]].copy()
+    wovov -= np.einsum('jf,mbfe->mbje',t1,MO[ov[0],ov[1],ov[1],ov[1]])
+    wovov += np.einsum('nb,mnje->mbje',t1,MO[ov[0],ov[0],ov[0],ov[1]])
     tmp = np.einsum('jf,nb->jnfb',t1,t1)
-    wmbej -= np.einsum('jnfb,mnef->mbej',0.5*t2+tmp,MO[ov[0],ov[0],ov[1],ov[1]])
-    return wmbej
+    wovov += np.einsum('mnfe,jnfb->mbje',MO[ov[0],ov[0],ov[1],ov[1]],(0.5*t2+tmp))
+    return wovov
+
+def build_Wovvo(MO,L,ov,t1,t2):
+    '''EQ 8'''
+    wovvo = MO[ov[0],ov[1],ov[1],ov[0]].copy()
+    wovvo += np.einsum('jf,mbef->mbej',t1,MO[ov[0],ov[1],ov[1],ov[1]])
+    wovvo -= np.einsum('nb,mnej->mbej',t1,MO[ov[0],ov[0],ov[1],ov[0]])
+    tmp = np.einsum('jf,nb->jnfb',t1,t1)
+    wovvo -= np.einsum('mnef,jnfb->mbej',MO[ov[0],ov[0],ov[1],ov[1]],(0.5*t2+tmp))
+    wovvo += 0.5*np.einsum('mnef,njfb->mbej',L[ov[0],ov[0],ov[1],ov[1]],t2)
+    return wovvo
+
+def build_W(MO,L,ov,t1,t2,tau):
+    woooo = build_Woooo(MO,ov,t1,t2,tau)
+    wovov = build_Wovov(MO,ov,t1,t2,tau)
+    wovvo = build_Wovvo(MO,L,ov,t1,t2)
+    return woooo,wovov,wovvo
+
+def build_Z(MO,ov,tau):
+    '''Necessary to avoid explicit building of Wvvvv'''
+    z_ovoo = np.einsum('mbef,ijef->mbij',MO[ov[0],ov[1],ov[1],ov[1]].copy(),tau)
+    return z_ovoo

--- a/mesp/scf.py
+++ b/mesp/scf.py
@@ -78,4 +78,6 @@ def do_scf(mol,
         eps, mol.C = diag(A,F)  
         Cdocc = mol.C[:, :ndocc] 
         mol.D = np.einsum('ik,jk->ij',Cdocc,Cdocc) # New density
-
+    
+    if mol.scf_computed == False:
+        print("SCF did not converge.")

--- a/mesp/so_cc2.py
+++ b/mesp/so_cc2.py
@@ -1,0 +1,225 @@
+import numpy as np
+import psi4
+import mesp
+
+def do_so_cc2(mol,
+            e_conv = 1e-12,
+            max_iter = 50):
+    '''
+    CC2 function
+    
+    Parameters
+    ----------
+    mol: MESP Molecule class
+    max_iter: int, maximum iterations for CC2
+    '''
+    
+    ### SETUP ###
+    if not mol.scf_computed:
+        mesp.do_scf(mol)
+
+    # Make a Mints helper and grab integrals from psi4
+    mints = psi4.core.MintsHelper(mol.p4wfn.basisset())
+    C_p4 = psi4.core.Matrix.from_array(mol.C) # need p4 Matrix
+    MO = np.asarray(mints.mo_spin_eri(C_p4,C_p4)) # antisymmetrized SO MO ERI
+
+    nso = MO.shape[0] # convenient number of spin orbitals
+    nocc = int(mol.nel) # number of occ orbitals
+    nvir = nso - nocc # number of vir orbitals
+    so_eps = np.repeat(mol.eps, 2) # spin-orbital sfc orbital energies
+
+    F = mol.Hc + 2*mol.J - mol.K # AO-basis Fock
+    F = np.einsum('uj,vi,uv', mol.C, mol.C, F) # MO-basis Fock
+    I = np.array([[1,0],
+                  [0,1]])
+    F = np.kron(F,I) # Expand and spin-tegrate, thanks Vibin!
+
+    # use slices to cut out occ and vir blocks
+    o = slice(0,nocc) 
+    v = slice(nocc,nso)
+    ov = (o,v) # tuple for passing into functions
+
+    MO_ijab = MO[o,o,v,v] # <ij||ab>
+
+    # Grab orbital energies. I know I could just tile mol.eps,
+    # but this is a good check if my Fock is correct
+    diag = np.diag(F) # orbital eigenvalues in a 1D array
+    F_occ = diag[:nocc] # grab first nocc diag elements
+    F_vir = diag[nocc:] # grab the last nvir elements
+
+    # Clever construction of denominator matrices- thanks Ashutosh!
+    D_ia = F_occ.reshape(-1,1) - F_vir # EQ 12
+    D_ijab = F_occ.reshape(-1,1,1,1) + F_occ.reshape(-1,1,1) - F_vir.reshape(-1,1) - F_vir # EQ 13
+
+    # Initial guesses
+    t1 = np.zeros((nocc,nvir))
+    t2 = MO_ijab / D_ijab
+
+    if not mol.mp2_computed:
+        E_MP2_CORR = 0.25 * np.einsum('ijab,ijab->',MO_ijab,t2)
+        E_MP2 = E_MP2_CORR + mol.E_SCF
+        mol.E_MP2 = E_MP2
+        print('MP2 energy (from CC2) = {}'.format(E_MP2))
+
+    # Start CC2 iterations
+    E_old = 0.0
+    for cc2_iter in range(1,max_iter):
+        # Build 2- and 4-index intermediates
+        Fae = build_Fae(F,MO,ov,t1,t2)
+        Fmi = build_Fmi(F,MO,ov,t1,t2)
+        Fme = build_Fme(F,MO,ov,t1)
+        Wmnij = build_Wmnij(MO,ov,t1,t2)
+        Wabef = build_Wabef(MO,ov,t1,t2)
+        Wmbej = build_Wmbej(MO,ov,t1,t2)
+
+        # Build approx 2- and 4-index intermediates
+        aprx_Fae = build_Fae(F,MO,ov,t1,t2,True)
+        aprx_Fmi = build_Fmi(F,MO,ov,t1,t2,True)
+        aprx_Fme = build_Fme(F,MO,ov,t1,True)
+        aprx_Wmnij = build_Wmnij(MO,ov,t1,t2,True)
+        aprx_Wabef = build_Wabef(MO,ov,t1,t2,True)
+
+        # Build T1
+        T1 = F[ov[0],ov[1]].copy()
+        T1 += np.einsum('ie,ae->ia',t1,Fae)
+        T1 -= np.einsum('ma,mi->ia',t1,Fmi)
+        T1 += np.einsum('imae,me->ia',t2,Fme)
+        T1 -= np.einsum('nf,naif->ia',t1,MO[ov[0],ov[1],ov[0],ov[1]])
+        T1 -= 0.5 * np.einsum('imef,maef->ia',t2,MO[ov[0],ov[1],ov[1],ov[1]])
+        T1 -= 0.5 * np.einsum('mnae,nmei->ia',t2,MO[ov[0],ov[0],ov[1],ov[0]])
+
+        # Build T2
+        T2 = MO[ov[0],ov[0],ov[1],ov[1]].copy()
+#        tmp = 0.5 * np.einsum('mb,me->be',t1,aprx_Fme)
+#        tmp = aprx_Fae - tmp
+#        T2 += np.einsum('ijae,be->ijab',t2,tmp)
+#        T2 -= np.einsum('ijbe,ae->ijab',t2,tmp) 
+        T2 += np.einsum('ijae,be->ijab',t2,aprx_Fae) # CC2 only needs pure-Fock Fae
+        T2 -= np.einsum('ijbe,ae->ijab',t2,aprx_Fae) # ''
+
+#        tmp = 0.5 * np.einsum('je,me->mj',t1,aprx_Fme)
+#        tmp = aprx_Fmi + tmp
+#        T2 -= np.einsum('imab,mj->ijab',t2,tmp)
+#        T2 += np.einsum('jmab,mi->ijab',t2,tmp) 
+        T2 -= np.einsum('imab,mj->ijab',t2,aprx_Fmi) # CC2 only needs pure-Fock Fmi
+        T2 += np.einsum('jmab,mi->ijab',t2,aprx_Fmi) # ''
+
+        tau = build_tau(t1,t2,True)
+        T2 += 0.5 * np.einsum('mnab,mnij->ijab',tau,aprx_Wmnij) # need aprx Tau and W
+        T2 += 0.5 * np.einsum('ijef,abef->ijab',tau,aprx_Wabef) # ''
+
+        T2 -= np.einsum('ie,ma,mbej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+#        T2 += np.einsum('imae,mbej->ijab',t2,Wmbej) # no t2*Fock pieces in t2*Wmbej
+        T2 += np.einsum('ie,mb,maej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+#        T2 -= np.einsum('imbe,maej->ijab',t2,Wmbej)
+        T2 += np.einsum('je,ma,mbei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+#        T2 -= np.einsum('jmae,mbei->ijab',t2,Wmbej)
+        T2 -= np.einsum('je,mb,maei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+#        T2 += np.einsum('jmbe,maei->ijab',t2,Wmbej)
+
+        T2 += np.einsum('ie,abej->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
+        T2 -= np.einsum('je,abei->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
+
+        T2 -= np.einsum('ma,mbij->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
+        T2 += np.einsum('mb,maij->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
+
+        # Update t1 and t2 amplitudes
+        t1 = T1 / D_ia
+        t2 = T2 / D_ijab
+
+        # Calculate the current CC2 correlation energy
+        E_CC2_CORR = np.einsum('ia,ia->',F[ov[0],ov[1]],t1)
+        E_CC2_CORR += 0.25 * np.einsum('ijab,ijab->',MO_ijab,t2)
+        E_CC2_CORR += 0.5 * np.einsum('ijab,ia,jb->',MO_ijab,t1,t1)
+#        print("Iteration {} . . .".format(cc2_iter))
+#        print("CC2 Correlation Energy = {}".format(E_CC2_CORR))
+
+        # Check convergence
+        if (abs(E_CC2_CORR - E_old) < e_conv):
+            E_CC2 = E_CC2_CORR + mol.E_SCF
+            mol.E_CC2 = E_CC2
+            mol.cc2_computed = True
+            print("CC2 converged in {} steps!\nCC2 Energy = {}".format(cc2_iter,E_CC2))
+            break
+        else:
+            E_old = E_CC2_CORR
+    if mol.cc2_computed == False:
+        print("CC2 did not converge after {} steps.".format(max_iter))
+        print("Current CC2 Correlation Energy = {}".format(E_CC2_CORR))
+
+# TAU BUILD FNS
+## here aprx will drop t2 terms
+def build_tau(t1,t2,aprx=False):
+    '''EQ 9'''
+    tau = np.einsum('ia,jb->ijab',t1,t1)
+    tau -= np.einsum('ib,ja->ijab',t1,t1)
+    if not aprx:
+        tau += t2
+    return tau
+
+def build_tildetau(t1,t2,aprx=False):
+    '''EQ 10'''
+    tildetau = 0.5 * np.einsum('ia,jb->ijab',t1,t1)
+    tildetau -= 0.5 * np.einsum('ib,ja->ijab',t1,t1)
+    if not aprx:
+        tildetau += t2
+    return tildetau
+
+# 2-INDEX INTERMEDIATES
+## here aprx will drop everything but pure Fock terms
+def build_Fae(F,MO,ov,t1,t2,aprx=False):
+    '''EQ 3'''
+    fae = F[ov[1],ov[1]].copy() # only need vir-vir block 
+    fae[np.diag_indices_from(fae)] = 0 # only need off-diag elements
+    if not aprx:
+        fae -= 0.5 * np.einsum('me,ma->ae',F[ov[0],ov[1]],t1)
+        fae += np.einsum('mf,mafe->ae',t1,MO[ov[0],ov[1],ov[1],ov[1]])
+        tildetau = build_tildetau(t1,t2)
+        fae -= 0.5 * np.einsum('mnaf,mnef->ae',tildetau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return fae
+
+def build_Fmi(F,MO,ov,t1,t2,aprx=False):
+    '''EQ 4'''
+    fmi = F[ov[0],ov[0]].copy() # occ-occ block
+    fmi[np.diag_indices_from(fmi)] = 0 # only need off-diag elements
+    fmi += 0.5 * np.einsum('ie,me->mi',t1,F[ov[0],ov[1]])
+    if not aprx:
+        fmi += np.einsum('ne,mnie->mi',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+        tildetau = build_tildetau(t1,t2,aprx)
+        fmi += 0.5 * np.einsum('inef,mnef->mi',tildetau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return fmi
+
+def build_Fme(F,MO,ov,t1,aprx=False):
+    '''EQ 5'''
+    fme = F[ov[0],ov[1]].copy() 
+    if not aprx:
+        fme += np.einsum('nf,mnef->me',t1,MO[ov[0],ov[0],ov[1],ov[1]])
+    return fme
+
+# 4-INDEX INTERMEDIATES
+def build_Wmnij(MO,ov,t1,t2,aprx=False):
+    '''EQ 6'''
+    wmnij = MO[ov[0],ov[0],ov[0],ov[0]].copy()
+    wmnij += np.einsum('je,mnie->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+    wmnij -= np.einsum('ie,mnje->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+    tau = build_tau(t1,t2,aprx)
+    wmnij += 0.25 * np.einsum('ijef,mnef->mnij',tau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return wmnij
+
+def build_Wabef(MO,ov,t1,t2,aprx=False):
+    '''EQ 7'''
+    wabef = MO[ov[1],ov[1],ov[1],ov[1]].copy()
+    wabef -= np.einsum('mb,amef->abef',t1,MO[ov[1],ov[0],ov[1],ov[1]])
+    wabef += np.einsum('ma,bmef->abef',t1,MO[ov[1],ov[0],ov[1],ov[1]])
+    tau = build_tau(t1,t2,aprx)
+    wabef += 0.25 * np.einsum('mnab,mnef->abef',tau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return wabef
+
+def build_Wmbej(MO,ov,t1,t2):
+    '''EQ 8'''
+    wmbej = MO[ov[0],ov[1],ov[1],ov[0]].copy()
+    wmbej += np.einsum('jf,mbef->mbej',t1,MO[ov[0],ov[1],ov[1],ov[1]])
+    wmbej -= np.einsum('nb,mnej->mbej',t1,MO[ov[0],ov[0],ov[1],ov[0]])
+    tmp = np.einsum('jf,nb->jnfb',t1,t1)
+    wmbej -= np.einsum('jnfb,mnef->mbej',0.5*t2+tmp,MO[ov[0],ov[0],ov[1],ov[1]])
+    return wmbej

--- a/mesp/so_ccsd.py
+++ b/mesp/so_ccsd.py
@@ -1,0 +1,204 @@
+import numpy as np
+import psi4
+import mesp
+
+def do_so_ccsd(mol,
+            e_conv = 1e-12,
+            max_iter = 50):
+    '''
+    Spin Orbital CCSD function
+    
+    Parameters
+    ----------
+    mol: MESP Molecule class
+    max_iter: int, maximum iterations for CCSD
+    '''
+    
+    ### SETUP ###
+    if not mol.scf_computed:
+        mesp.do_scf(mol)
+
+    # Make a Mints helper and grab integrals from psi4
+    mints = psi4.core.MintsHelper(mol.p4wfn.basisset())
+    C_p4 = psi4.core.Matrix.from_array(mol.C) # need p4 Matrix
+    MO = np.asarray(mints.mo_spin_eri(C_p4,C_p4)) # antisymmetrized SO MO ERI
+
+    nso = MO.shape[0] # convenient number of spin orbitals
+    nocc = int(mol.nel) # number of occ orbitals
+    nvir = nso - nocc # number of vir orbitals
+    so_eps = np.repeat(mol.eps, 2) # spin-orbital sfc orbital energies
+
+    F = mol.Hc + 2*mol.J - mol.K # AO-basis Fock
+    F = np.einsum('uj,vi,uv', mol.C, mol.C, F) # MO-basis Fock
+    I = np.array([[1,0],
+                  [0,1]])
+    F = np.kron(F,I) # Expand and spin-tegrate, thanks Vibin!
+
+    # use slices to cut out occ and vir blocks
+    o = slice(0,nocc) 
+    v = slice(nocc,nso)
+    ov = (o,v) # tuple for passing into functions
+
+    MO_ijab = MO[o,o,v,v] # <ij||ab>
+
+    # Grab orbital energies. I know I could just tile mol.eps,
+    # but this is a good check if my Fock is correct
+    diag = np.diag(F) # orbital eigenvalues in a 1D array
+    F_occ = diag[:nocc] # grab first nocc diag elements
+    F_vir = diag[nocc:] # grab the last nvir elements
+
+    # Clever construction of denominator matrices- thanks Ashutosh!
+    D_ia = F_occ.reshape(-1,1) - F_vir # EQ 12
+    D_ijab = F_occ.reshape(-1,1,1,1) + F_occ.reshape(-1,1,1) - F_vir.reshape(-1,1) - F_vir # EQ 13
+
+    # Initial guesses
+    t1 = np.zeros((nocc,nvir))
+    t2 = MO_ijab / D_ijab
+
+    if not mol.mp2_computed:
+        E_MP2_CORR = 0.25 * np.einsum('ijab,ijab->',MO_ijab,t2)
+        E_MP2 = E_MP2_CORR + mol.E_SCF
+        mol.E_MP2 = E_MP2
+        print('MP2 energy (from CCSD) = {}'.format(E_MP2))
+
+    # Start CCSD iterations
+    E_old = 0.0
+    for ccsd_iter in range(1,max_iter):
+        # Build 2- and 4-index intermediates
+        Fae = build_Fae(F,MO,ov,t1,t2)
+        Fmi = build_Fmi(F,MO,ov,t1,t2)
+        Fme = build_Fme(F,MO,ov,t1)
+        Wmnij = build_Wmnij(MO,ov,t1,t2)
+        Wabef = build_Wabef(MO,ov,t1,t2)
+        Wmbej = build_Wmbej(MO,ov,t1,t2)
+
+        # Build T1
+        T1 = F[ov[0],ov[1]].copy()
+        T1 += np.einsum('ie,ae->ia',t1,Fae)
+        T1 -= np.einsum('ma,mi->ia',t1,Fmi)
+        T1 += np.einsum('imae,me->ia',t2,Fme)
+        T1 -= np.einsum('nf,naif->ia',t1,MO[ov[0],ov[1],ov[0],ov[1]])
+        T1 -= 0.5 * np.einsum('imef,maef->ia',t2,MO[ov[0],ov[1],ov[1],ov[1]])
+        T1 -= 0.5 * np.einsum('mnae,nmei->ia',t2,MO[ov[0],ov[0],ov[1],ov[0]])
+
+        # Build T2
+        T2 = MO[ov[0],ov[0],ov[1],ov[1]].copy()
+        tmp = 0.5 * np.einsum('mb,me->be',t1,Fme)
+        tmp = Fae - tmp
+        T2 += np.einsum('ijae,be->ijab',t2,tmp)
+        T2 -= np.einsum('ijbe,ae->ijab',t2,tmp) # Questionable- rebuild tmp with P(ab)?
+
+        tmp = 0.5 * np.einsum('je,me->mj',t1,Fme)
+        tmp = Fmi + tmp
+        T2 -= np.einsum('imab,mj->ijab',t2,tmp)
+        T2 += np.einsum('jmab,mi->ijab',t2,tmp) # Also questionable
+
+        tau = build_tau(t1,t2)
+        T2 += 0.5 * np.einsum('mnab,mnij->ijab',tau,Wmnij)
+        T2 += 0.5 * np.einsum('ijef,abef->ijab',tau,Wabef)
+
+        T2 -= np.einsum('ie,ma,mbej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+        T2 += np.einsum('imae,mbej->ijab',t2,Wmbej)
+        T2 += np.einsum('ie,mb,maej->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+        T2 -= np.einsum('imbe,maej->ijab',t2,Wmbej)
+        T2 += np.einsum('je,ma,mbei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+        T2 -= np.einsum('jmae,mbei->ijab',t2,Wmbej)
+        T2 -= np.einsum('je,mb,maei->ijab',t1,t1,MO[ov[0],ov[1],ov[1],ov[0]])
+        T2 += np.einsum('jmbe,maei->ijab',t2,Wmbej)
+
+        T2 += np.einsum('ie,abej->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
+        T2 -= np.einsum('je,abei->ijab',t1,MO[ov[1],ov[1],ov[1],ov[0]])
+
+        T2 -= np.einsum('ma,mbij->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
+        T2 += np.einsum('mb,maij->ijab',t1,MO[ov[0],ov[1],ov[0],ov[0]])
+
+        # Update t1 and t2 amplitudes
+        t1 = T1 / D_ia
+        t2 = T2 / D_ijab
+
+        # Calculate the current CCSD correlation energy
+        E_CCSD_CORR = np.einsum('ia,ia->',F[ov[0],ov[1]],t1)
+        E_CCSD_CORR += 0.25 * np.einsum('ijab,ijab->',MO_ijab,t2)
+        E_CCSD_CORR += 0.5 * np.einsum('ijab,ia,jb->',MO_ijab,t1,t1)
+#        print("Iteration {} . . .".format(ccsd_iter))
+#        print("CCSD Correlation Energy = {}".format(E_CCSD_CORR))
+
+        # Check convergence
+        if (abs(E_CCSD_CORR - E_old) < e_conv):
+            E_CCSD = E_CCSD_CORR + mol.E_SCF
+            mol.E_CCSD = E_CCSD
+            mol.ccsd_computed = True
+            print("CCSD converged in {} steps!\nCCSD Energy = {}".format(ccsd_iter,E_CCSD))
+            break
+        else:
+            E_old = E_CCSD_CORR
+    if mol.ccsd_computed == False:
+        print("CCSD did not converge after {} steps.".format(max_iter))
+        print("Current CCSD Correlation Energy = {}".format(E_CCSD_CORR))
+
+# TAU BUILD FNS
+def build_tau(t1,t2):
+    '''EQ 9'''
+    tau = t2 + np.einsum('ia,jb->ijab',t1,t1)
+    tau -= np.einsum('ib,ja->ijab',t1,t1)
+    return tau
+
+def build_tildetau(t1,t2):
+    '''EQ 10'''
+    tildetau = t2 + 0.5 * np.einsum('ia,jb->ijab',t1,t1)
+    tildetau -= 0.5 * np.einsum('ib,ja->ijab',t1,t1)
+    return tildetau
+
+# 2-INDEX INTERMEDIATES
+def build_Fae(F,MO,ov,t1,t2):
+    '''EQ 3'''
+    fae = F[ov[1],ov[1]].copy() # only need vir-vir block 
+    fae[np.diag_indices_from(fae)] = 0 # only need off-diag elements
+    fae -= 0.5 * np.einsum('me,ma->ae',F[ov[0],ov[1]],t1)
+    fae += np.einsum('mf,mafe->ae',t1,MO[ov[0],ov[1],ov[1],ov[1]])
+    tildetau = build_tildetau(t1,t2)
+    fae -= 0.5 * np.einsum('mnaf,mnef->ae',tildetau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return fae
+
+def build_Fmi(F,MO,ov,t1,t2):
+    '''EQ 4'''
+    fmi = F[ov[0],ov[0]].copy() # occ-occ block
+    fmi[np.diag_indices_from(fmi)] = 0 # only need off-diag elements
+    fmi += 0.5 * np.einsum('ie,me->mi',t1,F[ov[0],ov[1]])
+    fmi += np.einsum('ne,mnie->mi',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+    tildetau = build_tildetau(t1,t2)
+    fmi += 0.5 * np.einsum('inef,mnef->mi',tildetau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return fmi
+
+def build_Fme(F,MO,ov,t1):
+    '''EQ 5'''
+    fme = F[ov[0],ov[1]].copy() + np.einsum('nf,mnef->me',t1,MO[ov[0],ov[0],ov[1],ov[1]])
+    return fme
+
+# 4-INDEX INTERMEDIATES
+def build_Wmnij(MO,ov,t1,t2):
+    '''EQ 6'''
+    wmnij = MO[ov[0],ov[0],ov[0],ov[0]].copy()
+    wmnij += np.einsum('je,mnie->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+    wmnij -= np.einsum('ie,mnje->mnij',t1,MO[ov[0],ov[0],ov[0],ov[1]])
+    tau = build_tau(t1,t2)
+    wmnij += 0.25 * np.einsum('ijef,mnef->mnij',tau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return wmnij
+
+def build_Wabef(MO,ov,t1,t2):
+    '''EQ 7'''
+    wabef = MO[ov[1],ov[1],ov[1],ov[1]].copy()
+    wabef -= np.einsum('mb,amef->abef',t1,MO[ov[1],ov[0],ov[1],ov[1]])
+    wabef += np.einsum('ma,bmef->abef',t1,MO[ov[1],ov[0],ov[1],ov[1]])
+    tau = build_tau(t1,t2)
+    wabef += 0.25 * np.einsum('mnab,mnef->abef',tau,MO[ov[0],ov[0],ov[1],ov[1]])
+    return wabef
+
+def build_Wmbej(MO,ov,t1,t2):
+    '''EQ 8'''
+    wmbej = MO[ov[0],ov[1],ov[1],ov[0]].copy()
+    wmbej += np.einsum('jf,mbef->mbej',t1,MO[ov[0],ov[1],ov[1],ov[1]])
+    wmbej -= np.einsum('nb,mnej->mbej',t1,MO[ov[0],ov[0],ov[1],ov[0]])
+    tmp = np.einsum('jf,nb->jnfb',t1,t1)
+    wmbej -= np.einsum('jnfb,mnef->mbej',0.5*t2+tmp,MO[ov[0],ov[0],ov[1],ov[1]])
+    return wmbej

--- a/tests/test_so_cc2.py
+++ b/tests/test_so_cc2.py
@@ -1,0 +1,32 @@
+import numpy as np
+import psi4
+psi4.core.be_quiet()
+import mesp
+
+geom = """
+    O
+    H 1 1
+    H 1 1 2 104.5
+    symmetry c1
+"""
+bas = "sto-3g"
+mol = mesp.Molecule('H2O',geom,bas)
+
+def test_so_cc2():
+    mesp.so_cc2.do_so_cc2(mol)
+    E_mesp = mol.E_CC2   
+
+    psi4.set_options({
+        'basis':bas,
+        'scf_type':'pk',
+        'mp2_type':'conv',
+        'freeze_core':'false',
+        'e_convergence':1e-12,
+        'd_convergence':1e-12})
+    E_psi4 = psi4.energy('CC2')
+    
+    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
+    assert np.allclose(E_psi4,E_mesp)
+
+if __name__=="__main__":
+    test_so_cc2()

--- a/tests/test_so_ccsd.py
+++ b/tests/test_so_ccsd.py
@@ -12,11 +12,8 @@ geom = """
 bas = "sto-3g"
 mol = mesp.Molecule('H2O',geom,bas)
 
-def test_ccsd():
-    mesp.scf.do_scf(mol,
-                    e_conv = 1e-12,
-                    max_iter = 100) # make sure SCF converges
-    mesp.ccsd.do_ccsd(mol)
+def test_so_ccsd():
+    mesp.so_ccsd.do_so_ccsd(mol)
     E_mesp = mol.E_CCSD    
 
     psi4.set_options({
@@ -32,4 +29,4 @@ def test_ccsd():
     assert np.allclose(E_psi4,E_mesp)
 
 if __name__=="__main__":
-    test_ccsd()
+    test_so_ccsd()


### PR DESCRIPTION
Spin-adapted CCSD and CC2 code. Equations derived via the Unitary Group Generator approach. Factorized roughly according to the [1991 Stanton CCSD paper](doi.org/10.1063/1.460620). Wvvvv intermediate construction avoided in favor of Z intermediate as in [UGACC](github.com/lothian/ugacc) by Prof. Crawford and [Psi4NumPy](https://github.com/psi4/psi4numpy/blob/master/Coupled-Cluster/RHF/helper_ccenergy.py#L230) by Ashutosh Kumar & AM James.

The CC2 code is still simply a cut-down CCSD code; a T1-transformed Hamiltonian is [planned](github.com/bgpeyton/mesp/issues/4).