### PR TITLE
DIIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ py.test
 
 ### Implemented methods:
 * SCF
+* * RHF (with DIIS)
 * MP2
+* * Spin-orbital
 * CCSD (spin-adapted and spin-orbital)
+* * Spin-orbital
+* * Spin-adapted (with DIIS)
 * CC2  (spin-adapted and spin-orbital)
+* * Spin-orbital
+* * Spin-adapted (with DIIS)

--- a/mesp/cc2.py
+++ b/mesp/cc2.py
@@ -215,6 +215,7 @@ def do_cc2(mol,
     if mol.cc2_computed == False:
         print("CC2 did not converge after {} steps.".format(max_iter))
         print("Current CC2 Correlation Energy = {}".format(E_CC2_CORR))
+        print("Current CC2 Energy = {}".format(E_CC2_CORR + mol.E_SCF))
 
 # TAU BUILD FNS
 ## here aprx will drop t2 terms

--- a/mesp/cc2.py
+++ b/mesp/cc2.py
@@ -3,8 +3,11 @@ import psi4
 import mesp
 
 def do_cc2(mol,
-            e_conv = 1e-12,
-            max_iter = 50):
+           e_conv = 1e-12,
+           max_iter = 50,
+           diis_start = 1,
+           diis_max = 8,
+           diis_step = 0):
     '''
     CC2 function
     
@@ -13,6 +16,9 @@ def do_cc2(mol,
     mol: MESP Molecule class
     e_conv: optional float (default = 1e-12), convergence criteria for energy
     max_iter: optional int (default = 50), maximum iterations for CC2
+    diis_start: optional int, first iteration where DIIS is performed
+    diis_max: optional int, max number of Fock and gradient matrices held for DIIS extrapolation
+    diis_step: optional int, allow `diis_step` relaxation cycles between DIIS extrapolation
 
     Notes
     ----------
@@ -75,6 +81,12 @@ def do_cc2(mol,
 
     # Start CC2 iterations
     E_old = 0.0
+    t1_list = [t1.copy()]
+    t2_list = [t2.copy()]
+    t1_old = t1.copy()
+    t2_old = t2.copy()
+    r_list = [] # Residual list (DIIS error vectors)
+    diis_count = 0
     for cc2_iter in range(1,max_iter):
 #        print("Iteration {} . . .".format(cc2_iter))
 
@@ -162,6 +174,44 @@ def do_cc2(mol,
             break
         else:
             E_old = E_CC2_CORR
+            t1_list.append(t1.copy())
+            t2_list.append(t2.copy())
+            r_t1 = (t1 - t1_old).ravel()
+            r_t2 = (t2 - t2_old).ravel()
+            r_list.append(np.concatenate((r_t1,r_t2)))
+            if len(t1_list) > diis_max:
+                del t1_list[0]
+                del t2_list[0]
+                del r_list[0]
+            
+            diis_count += 1
+            if cc2_iter >= diis_start and diis_count > diis_step: # See scf.py for DIIS notes
+                B = np.empty((len(r_list)+1,len(r_list)+1))
+                B[-1,:]  = -1
+                B[:,-1]  = -1
+                B[-1,-1] = 0
+                for i in range(0,len(r_list)):
+                    for j in range(0,len(r_list)):
+                        if j > i: continue
+                        B[i,j] = np.einsum('i,i->',r_list[i],r_list[j])
+                        B[j,i] = B[i,j]
+                B[:-1,:-1] /= np.abs(B[:-1,:-1]).max() 
+
+                rhs = np.zeros(B.shape[0])
+                rhs[-1] = -1
+
+                c = np.linalg.solve(B,rhs)
+
+                t1 = np.zeros_like(t1)
+                t2 = np.zeros_like(t2)
+                for i in range(len(r_list)):
+                    t1 += c[i] * t1_list[i+1]
+                    t2 += c[i] * t2_list[i+1]
+
+                diis_count = 0
+
+            t1_old = t1.copy() # Keep t1, whether it was DIIS-extrapolated or not
+            t2_old = t2.copy()
     if mol.cc2_computed == False:
         print("CC2 did not converge after {} steps.".format(max_iter))
         print("Current CC2 Correlation Energy = {}".format(E_CC2_CORR))

--- a/mesp/ccsd.py
+++ b/mesp/ccsd.py
@@ -18,7 +18,7 @@ def do_ccsd(mol,
     max_iter: optional int (default = 50), maximum iterations for CCSD
     diis_start: optional int, first iteration where DIIS is performed
     diis_max: optional int, max number of Fock and gradient matrices held for DIIS extrapolation
-    diis_step: optional int, allow `diis_step` full normal scf cycles between DIIS extrapolation
+    diis_step: optional int, allow `diis_step` relaxation cycles between DIIS extrapolation
 
     Notes
     ----------

--- a/mesp/ccsd.py
+++ b/mesp/ccsd.py
@@ -4,7 +4,10 @@ import mesp
 
 def do_ccsd(mol,
             e_conv = 1e-12,
-            max_iter = 50):
+            max_iter = 50,
+            diis_start = 1,
+            diis_max = 8,
+            diis_step = 0):
     '''
     CCSD function
     
@@ -13,6 +16,9 @@ def do_ccsd(mol,
     mol: MESP Molecule class
     e_conv: optional float (default = 1e-12), convergence criteria for energy
     max_iter: optional int (default = 50), maximum iterations for CCSD
+    diis_start: optional int, first iteration where DIIS is performed
+    diis_max: optional int, max number of Fock and gradient matrices held for DIIS extrapolation
+    diis_step: optional int, allow `diis_step` full normal scf cycles between DIIS extrapolation
 
     Notes
     ----------
@@ -72,6 +78,12 @@ def do_ccsd(mol,
 
     # Start CCSD iterations
     E_old = 0.0
+    t1_list = [t1.copy()]
+    t2_list = [t2.copy()]
+    t1_old = t1.copy()
+    t2_old = t2.copy()
+    r_list = [] # Residual list (DIIS error vectors)
+    diis_count = 0
     for ccsd_iter in range(1,max_iter):
 #        print("Iteration {} . . .".format(ccsd_iter))
 
@@ -159,9 +171,49 @@ def do_ccsd(mol,
             break
         else:
             E_old = E_CCSD_CORR
+            t1_list.append(t1.copy())
+            t2_list.append(t2.copy())
+            r_t1 = (t1 - t1_old).ravel()
+            r_t2 = (t2 - t2_old).ravel()
+            r_list.append(np.concatenate((r_t1,r_t2)))
+            if len(t1_list) > diis_max:
+                del t1_list[0]
+                del t2_list[0]
+                del r_list[0]
+            
+            diis_count += 1
+            if ccsd_iter >= diis_start and diis_count > diis_step: # See scf.py for DIIS notes
+                B = np.empty((len(r_list)+1,len(r_list)+1))
+                B[-1,:]  = -1
+                B[:,-1]  = -1
+                B[-1,-1] = 0
+                for i in range(0,len(r_list)):
+                    for j in range(0,len(r_list)):
+                        if j > i: continue
+                        B[i,j] = np.einsum('i,i->',r_list[i],r_list[j])
+                        B[j,i] = B[i,j]
+                B[:-1,:-1] /= np.abs(B[:-1,:-1]).max() 
+
+                rhs = np.zeros(B.shape[0])
+                rhs[-1] = -1
+
+                c = np.linalg.solve(B,rhs)
+
+                t1 = np.zeros_like(t1)
+                t2 = np.zeros_like(t2)
+                for i in range(len(r_list)):
+                    t1 += c[i] * t1_list[i+1]
+                    t2 += c[i] * t2_list[i+1]
+
+                diis_count = 0
+
+            t1_old = t1.copy() # Keep t1, whether it was DIIS-extrapolated or not
+            t2_old = t2.copy()
+
     if mol.ccsd_computed == False:
         print("CCSD did not converge after {} steps.".format(max_iter))
         print("Current CCSD Correlation Energy = {}".format(E_CCSD_CORR))
+        print("Current CCSD Energy = {}".format(E_CCSD_CORR + mol.E_SCF))
 
 # TAU BUILD FNS
 def build_tau(t1,t2):

--- a/mesp/scf.py
+++ b/mesp/scf.py
@@ -14,7 +14,10 @@ def diag(A,F):
 def do_scf(mol,
         e_conv = 1e-12,
         d_conv = 1e-12,
-        max_iter = 50):
+        max_iter = 50,
+        diis_start = 3,
+        diis_max = 6,
+        diis_step = 0):
     '''
     SCF function
     
@@ -24,6 +27,9 @@ def do_scf(mol,
     e_conv: float
     d_conv: float
     max_iter: int, maximum iterations for SCF
+    diis_start: int, first iteration where DIIS is performed
+    diis_max: int, max number of Fock and gradient matrices held for DIIS extrapolation
+    diis_step: int, allow `diis_step` full normal scf cycles between DIIS extrapolation
     '''
     
     ### SETUP ###
@@ -49,6 +55,10 @@ def do_scf(mol,
     Cdocc = mol.C[:, :ndocc] # Coefficients of occupied orbitals only: only keep ndocc columns
     mol.D = np.einsum('ik,jk->ij',Cdocc,Cdocc) # Initial density
 
+    F_list = [] # List of F for DIIS
+    r_list = [] # List of residuals (gradients) for DIIS
+    diis_count = 0 # Keep track of steps between DIIS
+
     ### START SCF ###
     E_old = 0
     D_old = np.zeros_like(mol.D)
@@ -58,11 +68,17 @@ def do_scf(mol,
 
         F = mol.Hc + 2*mol.J - mol.K # Compute Fock matrix
 
-        E_SCF = np.einsum('ij,ij->',mol.D,mol.Hc+F) + E_nuc# Compute SCF energy
+        E_SCF = np.einsum('ij,ij->',mol.D,mol.Hc+F) + E_nuc # Compute SCF energy
 
         grad = np.einsum('ij,jk,kl->il',F,mol.D,S) - np.einsum('ij,jk,kl->il',S,mol.D,F)
-        grad = A.T @ grad @ A
-        rms = np.mean(grad**2)**0.5
+        grad = A.T @ grad @ A # Compute orthogonormalized orbital gradient
+        rms = np.mean(grad**2)**0.5 # Compute RMSD of the orbital gradient
+        
+        F_list.append(F)
+        r_list.append(grad)
+        if len(F_list) > diis_max:
+            del F_list[0]
+            del r_list[0]
 
         if ((abs(E_SCF - E_old) < e_conv) and (rms < d_conv)):
             print("SCF converged in {} steps!\nSCF Energy = {}".format(scf_iter,E_SCF))
@@ -70,9 +86,29 @@ def do_scf(mol,
             mol.E_SCF = E_SCF
             mol.eps = eps
             break
+    
+        diis_count += 1
+        if scf_iter >= diis_start and diis_count > diis_step:
+            B = np.empty((len(F_list)+1,len(F_list)+1)) # Build B matrix to solve Pulay Eqn
+            B[-1,:]  = -1 #   [<r|r> ..  -1] [c1]   [0 ]
+            B[:,-1]  = -1 #   [ ..   ..  ..] [..] = [..]
+            B[-1,-1] = -1 #   [ -1   ..   0] [L ]   [-1]
+            for i in range(0,len(F_list)): # Compute overlaps <r_i|r_j>
+                for j in range(0,len(F_list)):
+                    B[i,j] = np.einsum('ij,ij->',r_list[i],r_list[j])
 
-        E_old = E_SCF
+            rhs = np.zeros(B.shape[0])
+            rhs[-1] = -1
 
+            c = np.linalg.solve(B,rhs) # Solve Pulay eq for coefficient vector
+
+            F = np.zeros_like(F) # Solve DIIS Fock
+            for i in range(c.shape[0] - 1):
+                F += c[i] * F_list[i] # Linear combination of F_list
+
+            diis_count = 0 # Reset DIIS counter
+
+        E_old = E_SCF # Get ready for the next SCF cycle
         D_old = mol.D
 
         eps, mol.C = diag(A,F)  

--- a/mesp/scf.py
+++ b/mesp/scf.py
@@ -92,10 +92,13 @@ def do_scf(mol,
             B = np.empty((len(F_list)+1,len(F_list)+1)) # Build B matrix to solve Pulay Eqn
             B[-1,:]  = -1 #   [<r|r> ..  -1] [c1]   [0 ]
             B[:,-1]  = -1 #   [ ..   ..  ..] [..] = [..]
-            B[-1,-1] = -1 #   [ -1   ..   0] [L ]   [-1]
+            B[-1,-1] = 0  #   [ -1   ..   0] [L ]   [-1]
             for i in range(0,len(F_list)): # Compute overlaps <r_i|r_j>
                 for j in range(0,len(F_list)):
+                    if j > i: continue
                     B[i,j] = np.einsum('ij,ij->',r_list[i],r_list[j])
+                    B[j,i] = B[i,j] # B is symmetric!
+            B[:-1,:-1] /= np.abs(B[:-1,:-1]).max() # Normalize
 
             rhs = np.zeros(B.shape[0])
             rhs[-1] = -1


### PR DESCRIPTION
Closes [issue #7](github.com/bgpeyton/mesp/issues/7). Adds DIIS functionality to RHF, CCSD (spin-adapted only), and CC2 (spin-adapted only). Only spin-adapted CC is considered because 1) that's what most of my work will be with anyway, and 2) the reduction in size of the t-amplitudes in spin-adapted CC makes DIIS more feasible. 

All codes have optional DIIS starting iterations, max DIIS subspace, and relaxation step parameters. Since the procedures are so similar, a DIIS helper may want to be created, but that will be saved for another time. 