### PR TITLE
Molecule Library Tests

### DIFF
--- a/mesp/__init__.py
+++ b/mesp/__init__.py
@@ -10,6 +10,7 @@ from . import so_ccsd
 from . import cc2
 from . import so_cc2
 
+from .mollib import mollib
 from .molecule import Molecule
 from .scf import do_scf
 from .mp2 import do_mp2

--- a/mesp/mollib.py
+++ b/mesp/mollib.py
@@ -1,0 +1,91 @@
+"""
+Library of molecules from MolSSI QuESt
+"""
+
+water_molecule = """
+O
+H 1 1.1
+H 1 1.1 2 104
+"""
+
+co_molecule = """
+C
+O 1 0.955
+"""
+
+co2_molecule = """
+C
+O 1 1.16
+O 1 1.16 2 180
+"""
+
+acetylene_molecule = """
+H
+C 1 HC
+X 2 XL 1 A1
+C 2 CC 3 A1 1 D1
+X 3 XL 2 A1 4 D2
+H 4 HC 5 A1 2 D1
+
+HC = 1.08
+XL = 1.0
+CC = 1.2
+A1 = 90.0
+D1 = 180.0
+D2 = 0.0
+"""
+
+benzene_molecule = """
+X
+X 1 1.0
+C 2 XC 1 A1
+C 2 XC 1 A1 3 60.0
+C 2 XC 1 A1 4 60.0
+C 2 XC 1 A1 5 60.0
+C 2 XC 1 A1 6 60.0
+C 2 XC 1 A1 7 60.0
+X 3 1.0 2 A1 1 0.0
+H 3 HC 9 A1 2 180.0
+H 4 HC 3 A2 2 180.0
+H 5 HC 4 A2 2 180.0
+H 6 HC 5 A2 2 180.0
+H 7 HC 6 A2 2 180.0
+H 8 HC 7 A2 2 180.0
+
+A1 = 90.0
+A2 = 120.0
+XC = 1.3
+HC = 1.08
+
+"""
+
+ethylene_molecule = """
+H
+C 1 HC
+H 2 HC 1 A1
+C 2 CC 3 A1 1 D1
+H 4 HC 2 A1 1 D1
+H 4 HC 2 A1 1 D2
+
+HC = 1.08
+CC = 1.4
+A1 = 120.0
+D1 = 180.0
+D2 = 0.0
+"""
+
+mollib = {}
+mollib["H2O"] = water_molecule
+#mollib["CO"] = co_molecule
+mollib["CO2"] = co2_molecule
+#mollib["C2H2"] = acetylene_molecule
+mollib["C2H4"] = ethylene_molecule
+#mollib["C6H6"] = benzene_molecule 
+
+### NOTES ###
+# CO
+# # SCF/DZ could not converge to 1e-8, stuck in well (implement damping)
+# C2H2
+# # SCF/STO-3G could not converge to 1e-8 rms, 100 iterations
+# C6H6
+# # SCF could not converge to 1e-6, 100 iterations

--- a/mesp/mollib.py
+++ b/mesp/mollib.py
@@ -83,9 +83,4 @@ mollib["C2H4"] = ethylene_molecule
 #mollib["C6H6"] = benzene_molecule 
 
 ### NOTES ###
-# CO
-# # SCF/DZ could not converge to 1e-8, stuck in well (implement damping)
-# C2H2
-# # SCF/STO-3G could not converge to 1e-8 rms, 100 iterations
-# C6H6
-# # SCF could not converge to 1e-6, 100 iterations
+# CO, C2H2, and C6H6 commented out due to long test times

--- a/mesp/scf.py
+++ b/mesp/scf.py
@@ -62,7 +62,7 @@ def do_scf(mol,
     ### START SCF ###
     E_old = 0
     D_old = np.zeros_like(mol.D)
-    for scf_iter in range(1,max_iter):
+    for scf_iter in range(1,max_iter+1):
         mol.J = np.einsum('rs,pqrs->pq',mol.D,ERI) # Compute Coulomb term
         mol.K = np.einsum('rs,prqs->pq',mol.D,ERI) # Compute Exhange term
 
@@ -79,6 +79,9 @@ def do_scf(mol,
         if len(F_list) > diis_max:
             del F_list[0]
             del r_list[0]
+
+        if debug:
+            print("Iter {}: E = {}, rms = {}".format(scf_iter,E_SCF,rms))
 
         if ((abs(E_SCF - E_old) < e_conv) and (rms < d_conv)):
             print("SCF converged in {} steps!\nSCF Energy = {}".format(scf_iter,E_SCF))

--- a/mesp/scf.py
+++ b/mesp/scf.py
@@ -80,9 +80,6 @@ def do_scf(mol,
             del F_list[0]
             del r_list[0]
 
-        if debug:
-            print("Iter {}: E = {}, rms = {}".format(scf_iter,E_SCF,rms))
-
         if ((abs(E_SCF - E_old) < e_conv) and (rms < d_conv)):
             print("SCF converged in {} steps!\nSCF Energy = {}".format(scf_iter,E_SCF))
             mol.scf_computed = True

--- a/tests/test_cc2.py
+++ b/tests/test_cc2.py
@@ -3,30 +3,33 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-geom = """
-    O
-    H 1 1
-    H 1 1 2 104.5
-    symmetry c1
-"""
-bas = "sto-3g"
-mol = mesp.Molecule('H2O',geom,bas)
-
 def test_cc2():
-    mesp.cc2.do_cc2(mol)
-    E_mesp = mol.E_CC2   
+    bas_list = ['STO-3G','DZ']
+    mol_list = ['H2O']
+    for name in mol_list:
+        geom = mesp.mollib[name]
+        geom += '\nsymmetry c1'
+        for bas in bas_list:
+            psi4.core.clean()
+            mol = mesp.Molecule(name,geom,bas)
+            psi4.set_options({
+                'basis':bas,
+                'scf_type':'pk',
+                'freeze_core':'false',
+                'e_convergence':1e-12,
+                'd_convergence':1e-12})
+            psi4.set_module_options('SCF', 
+                {'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                 'DIIS': True, 'scf_type':'pk'})
 
-    psi4.set_options({
-        'basis':bas,
-        'scf_type':'pk',
-        'mp2_type':'conv',
-        'freeze_core':'false',
-        'e_convergence':1e-12,
-        'd_convergence':1e-12})
-    E_psi4 = psi4.energy('CC2')
-    
-    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
-    assert np.allclose(E_psi4,E_mesp)
+            print("Results for {}/CC2/{}".format(name,bas))
+            mesp.cc2.do_cc2(mol)
+            E_mesp = mol.E_CC2    
+            E_psi4 = psi4.energy('CC2',molecule=mol.p4mol)
+            
+            print("mesp energy: {}".format(E_mesp))
+            print("Psi4 energy: {}\n\n".format(E_psi4))
+            psi4.compare_values(E_psi4,E_mesp,11,"CC2 Energy")
 
 if __name__=="__main__":
     test_cc2()

--- a/tests/test_ccsd.py
+++ b/tests/test_ccsd.py
@@ -3,33 +3,33 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-geom = """
-    O
-    H 1 1
-    H 1 1 2 104.5
-    symmetry c1
-"""
-bas = "sto-3g"
-mol = mesp.Molecule('H2O',geom,bas)
-
 def test_ccsd():
-    mesp.scf.do_scf(mol,
-                    e_conv = 1e-12,
-                    max_iter = 100) # make sure SCF converges
-    mesp.ccsd.do_ccsd(mol)
-    E_mesp = mol.E_CCSD    
+    bas_list = ['STO-3G','DZ']
+    mol_list = ['H2O']
+    for name in mol_list:
+        geom = mesp.mollib[name]
+        geom += '\nsymmetry c1'
+        for bas in bas_list:
+            psi4.core.clean()
+            mol = mesp.Molecule(name,geom,bas)
+            psi4.set_options({
+                'basis':bas,
+                'scf_type':'pk',
+                'freeze_core':'false',
+                'e_convergence':1e-12,
+                'd_convergence':1e-12})
+            psi4.set_module_options('SCF', 
+                {'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                 'DIIS': True, 'scf_type':'pk'})
 
-    psi4.set_options({
-        'basis':bas,
-        'scf_type':'pk',
-        'mp2_type':'conv',
-        'freeze_core':'false',
-        'e_convergence':1e-12,
-        'd_convergence':1e-12})
-    E_psi4 = psi4.energy('CCSD')
-    
-    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
-    assert np.allclose(E_psi4,E_mesp)
+            print("Results for {}/CCSD/{}".format(name,bas))
+            mesp.ccsd.do_ccsd(mol)
+            E_mesp = mol.E_CCSD    
+            E_psi4 = psi4.energy('CCSD',molecule=mol.p4mol)
+            
+            print("mesp energy: {}".format(E_mesp))
+            print("Psi4 energy: {}\n\n".format(E_psi4))
+            psi4.compare_values(E_psi4,E_mesp,11,"CCSD Energy")
 
 if __name__=="__main__":
     test_ccsd()

--- a/tests/test_mp2.py
+++ b/tests/test_mp2.py
@@ -3,30 +3,34 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-geom = """
-    O
-    H 1 1
-    H 1 1 2 104.5
-    symmetry c1
-"""
-bas = "sto-3g"
-mol = mesp.Molecule('H2O',geom,bas)
-
 def test_mp2():
-    mesp.mp2.do_mp2(mol)
-    E_mesp = mol.E_MP2    
+    bas_list = ['STO-3G','DZ'] 
+    mol_list = ['H2O']
+    for name in mol_list:
+        geom = mesp.mollib[name]
+        geom += '\nsymmetry c1'
+        for bas in bas_list:
+            psi4.core.clean()
+            mol = mesp.Molecule(name,geom,bas)
+            psi4.set_options({
+                'basis':bas,
+                'scf_type':'pk',
+                'mp2_type':'conv',
+                'freeze_core':'false',
+                'e_convergence':1e-12,
+                'd_convergence':1e-12})
+            psi4.set_module_options('SCF', 
+                {'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                 'DIIS': True, 'scf_type':'pk'})
 
-    psi4.set_options({
-        'basis':bas,
-        'scf_type':'pk',
-        'mp2_type':'conv',
-        'freeze_core':'false',
-        'e_convergence':1e-12,
-        'd_convergence':1e-12})
-    E_psi4 = psi4.energy('MP2')
+            print("Results for {}/MP2/{}".format(name,bas))
+            mesp.mp2.do_mp2(mol)
+            E_mesp = mol.E_MP2    
+            E_psi4 = psi4.energy('MP2')
     
-    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
-    assert np.allclose(E_psi4,E_mesp)
+            print("mesp energy: {}".format(E_mesp))
+            print("Psi4 energy: {}".format(E_psi4))
+            psi4.compare_values(E_psi4,E_mesp,11,"MP2 Energy")
 
 if __name__=="__main__":
     test_mp2()

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -3,31 +3,43 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-geom = """
-    O
-    H 1 1
-    H 1 1 2 104.5
-    symmetry c1
-"""
-bas = "sto-3g"
-mol = mesp.Molecule('H2O',geom,bas)
+#geom = """
+#    O
+#    H 1 1
+#    H 1 1 2 104.5
+#    symmetry c1
+#"""
+#bas = "sto-3g"
+#mol = mesp.Molecule('H2O',geom,bas)
 
 def test_scf():
-    mesp.scf.do_scf(mol)
-    E_mesp = mol.E_SCF    
+    bas_list = ['STO-3G','DZ','DZP']
+    for name,geom in mesp.mollib.items():
+        for bas in bas_list:
+            psi4.core.clean()
+            geom += '\nsymmetry c1'
+            mol = mesp.Molecule(name,geom,bas)
+            psi4.set_options({
+                'basis':bas,
+                'scf_type':'pk',
+                'freeze_core':'false',
+                'e_convergence':1e-8,
+                'd_convergence':1e-8})
+            psi4.set_module_options('SCF', 
+                    {'DIIS': False,
+                     'MAXITER': 80})
 
-    psi4.set_options({
-        'basis':bas,
-        'scf_type':'pk',
-        'freeze_core':'false',
-        'e_convergence':1e-12,
-        'd_convergence':1e-12})
-    psi4.set_module_options('SCF', {'e_convergence': 1e-12, 'd_convergence': 1e-12,
-        'DIIS': False,'scf_type':'pk'})
-    E_psi4 = psi4.energy('SCF')
-    
-    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
-    assert np.allclose(E_psi4,E_mesp)
+            print("Results for {}/SCF/{}".format(name,bas))
+            if name == 'C2H2':
+                mesp.scf.do_scf(mol,max_iter=100,debug=True)
+            else:
+                mesp.scf.do_scf(mol)
+            E_mesp = mol.E_SCF    
+            E_psi4 = psi4.energy('SCF',molecule=mol.p4mol)
+            
+            print("mesp energy: {}".format(E_mesp))
+            print("Psi4 energy: {}\n\n".format(E_psi4))
+            assert np.allclose(E_psi4,E_mesp)
 
 if __name__=="__main__":
     test_scf()

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -3,43 +3,33 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-#geom = """
-#    O
-#    H 1 1
-#    H 1 1 2 104.5
-#    symmetry c1
-#"""
-#bas = "sto-3g"
-#mol = mesp.Molecule('H2O',geom,bas)
-
 def test_scf():
     bas_list = ['STO-3G','DZ','DZP']
-    for name,geom in mesp.mollib.items():
+    mol_list = ['H2O', 'CO2', 'C2H4']
+    for name in mol_list:
+        geom = mesp.mollib[name]
+        geom += '\nsymmetry c1'
         for bas in bas_list:
             psi4.core.clean()
-            geom += '\nsymmetry c1'
             mol = mesp.Molecule(name,geom,bas)
             psi4.set_options({
                 'basis':bas,
                 'scf_type':'pk',
                 'freeze_core':'false',
-                'e_convergence':1e-8,
-                'd_convergence':1e-8})
+                'e_convergence':1e-12,
+                'd_convergence':1e-12})
             psi4.set_module_options('SCF', 
-                    {'DIIS': False,
-                     'MAXITER': 80})
+                {'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                 'DIIS': True, 'scf_type':'pk'})
 
             print("Results for {}/SCF/{}".format(name,bas))
-            if name == 'C2H2':
-                mesp.scf.do_scf(mol,max_iter=100,debug=True)
-            else:
-                mesp.scf.do_scf(mol)
+            mesp.scf.do_scf(mol)
             E_mesp = mol.E_SCF    
             E_psi4 = psi4.energy('SCF',molecule=mol.p4mol)
             
             print("mesp energy: {}".format(E_mesp))
             print("Psi4 energy: {}\n\n".format(E_psi4))
-            assert np.allclose(E_psi4,E_mesp)
+            psi4.compare_values(E_psi4,E_mesp,11,"RHF Energy")
 
 if __name__=="__main__":
     test_scf()

--- a/tests/test_so_cc2.py
+++ b/tests/test_so_cc2.py
@@ -3,30 +3,33 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-geom = """
-    O
-    H 1 1
-    H 1 1 2 104.5
-    symmetry c1
-"""
-bas = "sto-3g"
-mol = mesp.Molecule('H2O',geom,bas)
-
 def test_so_cc2():
-    mesp.so_cc2.do_so_cc2(mol)
-    E_mesp = mol.E_CC2   
+    bas_list = ['STO-3G','DZ']
+    mol_list = ['H2O']
+    for name in mol_list:
+        geom = mesp.mollib[name]
+        geom += '\nsymmetry c1'
+        for bas in bas_list:
+            psi4.core.clean()
+            mol = mesp.Molecule(name,geom,bas)
+            psi4.set_options({
+                'basis':bas,
+                'scf_type':'pk',
+                'freeze_core':'false',
+                'e_convergence':1e-12,
+                'd_convergence':1e-12})
+            psi4.set_module_options('SCF', 
+                {'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                 'DIIS': True, 'scf_type':'pk'})
 
-    psi4.set_options({
-        'basis':bas,
-        'scf_type':'pk',
-        'mp2_type':'conv',
-        'freeze_core':'false',
-        'e_convergence':1e-12,
-        'd_convergence':1e-12})
-    E_psi4 = psi4.energy('CC2')
-    
-    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
-    assert np.allclose(E_psi4,E_mesp)
+            print("Results for {}/SO-CC2/{}".format(name,bas))
+            mesp.so_cc2.do_so_cc2(mol)
+            E_mesp = mol.E_CC2    
+            E_psi4 = psi4.energy('CC2',molecule=mol.p4mol)
+            
+            print("mesp energy: {}".format(E_mesp))
+            print("Psi4 energy: {}\n\n".format(E_psi4))
+            psi4.compare_values(E_psi4,E_mesp,11,"SO-CC2 Energy")
 
 if __name__=="__main__":
     test_so_cc2()

--- a/tests/test_so_ccsd.py
+++ b/tests/test_so_ccsd.py
@@ -3,30 +3,33 @@ import psi4
 psi4.core.be_quiet()
 import mesp
 
-geom = """
-    O
-    H 1 1
-    H 1 1 2 104.5
-    symmetry c1
-"""
-bas = "sto-3g"
-mol = mesp.Molecule('H2O',geom,bas)
-
 def test_so_ccsd():
-    mesp.so_ccsd.do_so_ccsd(mol)
-    E_mesp = mol.E_CCSD    
+    bas_list = ['STO-3G','DZ']
+    mol_list = ['H2O']
+    for name in mol_list:
+        geom = mesp.mollib[name]
+        geom += '\nsymmetry c1'
+        for bas in bas_list:
+            psi4.core.clean()
+            mol = mesp.Molecule(name,geom,bas)
+            psi4.set_options({
+                'basis':bas,
+                'scf_type':'pk',
+                'freeze_core':'false',
+                'e_convergence':1e-12,
+                'd_convergence':1e-12})
+            psi4.set_module_options('SCF', 
+                {'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                 'DIIS': True, 'scf_type':'pk'})
 
-    psi4.set_options({
-        'basis':bas,
-        'scf_type':'pk',
-        'mp2_type':'conv',
-        'freeze_core':'false',
-        'e_convergence':1e-12,
-        'd_convergence':1e-12})
-    E_psi4 = psi4.energy('CCSD')
-    
-    print("Psi4 energy: {}\nmesp energy: {}".format(E_psi4,E_mesp))
-    assert np.allclose(E_psi4,E_mesp)
+            print("Results for {}/SO-CCSD/{}".format(name,bas))
+            mesp.so_ccsd.do_so_ccsd(mol)
+            E_mesp = mol.E_CCSD    
+            E_psi4 = psi4.energy('CCSD',molecule=mol.p4mol)
+            
+            print("mesp energy: {}".format(E_mesp))
+            print("Psi4 energy: {}\n\n".format(E_psi4))
+            psi4.compare_values(E_psi4,E_mesp,11,"SO-CCSD Energy")
 
 if __name__=="__main__":
     test_so_ccsd()


### PR DESCRIPTION
This PR addresses [#5](github.com/bgpeyton/mesp/issues/5). A small molecule library `mollib.py` was added, and the test suite now pulls geometries from that file. The test suite also loops over different basis sets, depending on the test (expensive jobs like CCSD are still only using water, but now with two basis sets). This should allow for quick testing of larger molecules from the library as spot-checks for future codes.