### PR TITLE
Add save_t option to all CC code

### DIFF
--- a/mesp/cc2.py
+++ b/mesp/cc2.py
@@ -7,7 +7,8 @@ def do_cc2(mol,
            max_iter = 50,
            diis_start = 1,
            diis_max = 8,
-           diis_step = 0):
+           diis_step = 0,
+           save_t = False):
     '''
     CC2 function
     
@@ -19,6 +20,7 @@ def do_cc2(mol,
     diis_start: optional int, first iteration where DIIS is performed
     diis_max: optional int, max number of Fock and gradient matrices held for DIIS extrapolation
     diis_step: optional int, allow `diis_step` relaxation cycles between DIIS extrapolation
+    save_t: optional bool (default = False), save final t-amplitudes
 
     Notes
     ----------
@@ -171,6 +173,9 @@ def do_cc2(mol,
             mol.E_CC2 = E_CC2
             mol.cc2_computed = True
             print('CC2 converged in {} steps!\nCC2 Energy = {}'.format(cc2_iter,E_CC2))
+            if save_t:
+                mol.t1 = t1
+                mol.t2 = t2
             break
         else:
             E_old = E_CC2_CORR

--- a/mesp/ccsd.py
+++ b/mesp/ccsd.py
@@ -7,7 +7,8 @@ def do_ccsd(mol,
             max_iter = 50,
             diis_start = 1,
             diis_max = 8,
-            diis_step = 0):
+            diis_step = 0,
+            save_t = False):
     '''
     CCSD function
     
@@ -19,6 +20,7 @@ def do_ccsd(mol,
     diis_start: optional int, first iteration where DIIS is performed
     diis_max: optional int, max number of Fock and gradient matrices held for DIIS extrapolation
     diis_step: optional int, allow `diis_step` relaxation cycles between DIIS extrapolation
+    save_t: optional bool (default = False), save final t-amplitudes
 
     Notes
     ----------
@@ -168,6 +170,9 @@ def do_ccsd(mol,
             mol.E_CCSD = E_CCSD
             mol.ccsd_computed = True
             print('CCSD converged in {} steps!\nCCSD Energy = {}'.format(ccsd_iter,E_CCSD))
+            if save_t:
+                mol.t1 = t1
+                mol.t2 = t2
             break
         else:
             E_old = E_CCSD_CORR

--- a/mesp/molecule.py
+++ b/mesp/molecule.py
@@ -30,4 +30,6 @@ class Molecule:
         self.E_SCF = False
         self.E_MP2 = False
         self.E_CCSD = False
+        self.t1 = False
+        self.t2 = False
         self.E_CC2 = False

--- a/mesp/so_cc2.py
+++ b/mesp/so_cc2.py
@@ -4,7 +4,8 @@ import mesp
 
 def do_so_cc2(mol,
             e_conv = 1e-12,
-            max_iter = 50):
+            max_iter = 50,
+            save_t = False):
     '''
     CC2 function
     
@@ -12,6 +13,7 @@ def do_so_cc2(mol,
     ----------
     mol: MESP Molecule class
     max_iter: int, maximum iterations for CC2
+    save_t: optional bool (default = False), save final t-amplitudes
     '''
     
     ### SETUP ###
@@ -140,6 +142,9 @@ def do_so_cc2(mol,
             mol.E_CC2 = E_CC2
             mol.cc2_computed = True
             print("CC2 converged in {} steps!\nCC2 Energy = {}".format(cc2_iter,E_CC2))
+            if save_t:
+                mol.t1 = t1
+                mol.t2 = t2
             break
         else:
             E_old = E_CC2_CORR

--- a/mesp/so_ccsd.py
+++ b/mesp/so_ccsd.py
@@ -4,7 +4,8 @@ import mesp
 
 def do_so_ccsd(mol,
             e_conv = 1e-12,
-            max_iter = 50):
+            max_iter = 50,
+            save_t = False):
     '''
     Spin Orbital CCSD function
     
@@ -12,6 +13,7 @@ def do_so_ccsd(mol,
     ----------
     mol: MESP Molecule class
     max_iter: int, maximum iterations for CCSD
+    save_t: optional bool (default = False), save final t-amplitudes
     '''
     
     ### SETUP ###
@@ -129,6 +131,9 @@ def do_so_ccsd(mol,
             mol.E_CCSD = E_CCSD
             mol.ccsd_computed = True
             print("CCSD converged in {} steps!\nCCSD Energy = {}".format(ccsd_iter,E_CCSD))
+            if save_t:
+                mol.t1 = t1
+                mol.t2 = t2
             break
         else:
             E_old = E_CCSD_CORR


### PR DESCRIPTION
As the name states, optional for saving the t amplitudes to the molecule. These will be large, but useful for debugging. Originally intended for creating a T-Amplitude Tensor Representation (TATR), as in a recent paper (doi.org/10.1021/acs.jpca.8b04455).